### PR TITLE
(#1) Changed blockBreakEvent priority to LOWEST and ignoreCancelled

### DIFF
--- a/src/main/java/me/nurio/imperial/founddiamonds/listeners/PlayerMinningOresListener.java
+++ b/src/main/java/me/nurio/imperial/founddiamonds/listeners/PlayerMinningOresListener.java
@@ -6,12 +6,13 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 
 public class PlayerMinningOresListener implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void blockBreakEvent(BlockBreakEvent eve) {
         // Check if the broken block is a mineral ore.
         Block block = eve.getBlock();


### PR DESCRIPTION
In order to avoid sending messages when the user doesn't have permissions to break a block, change priority and handle event cancellation.